### PR TITLE
Add shareProcessNamespace to etcd statefulset

### DIFF
--- a/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/etcd/templates/etcd-statefulset.yaml
@@ -45,6 +45,7 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
+      shareProcessNamespace: true
       containers:
 {{- if (not .Values.sourceStore) }}
       - name: etcd
@@ -351,6 +352,10 @@ spec:
           mountPath: "/root/.source-gcp/"
 {{- end }}
 {{- end }}
+        securityContext:
+          capabilities:
+            add:
+            - SYS_PTRACE
       volumes:
       - name: etcd-bootstrap-sh
         configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `shareProcessNamespace` to etcd statefulset to allow the etcd process to be killed from the `backup-restore` container.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
